### PR TITLE
revert to using a generic template for Dockerfile

### DIFF
--- a/12.04/Makefile
+++ b/12.04/Makefile
@@ -1,4 +1,0 @@
-all:
-	@docker build -t nitrousio/ubuntu-dind:12.04 .
-
-.PHONY: all

--- a/14.04/Dockerfile
+++ b/14.04/Dockerfile
@@ -1,3 +1,4 @@
+# Auto generated Dockerfile, please dont edit
 FROM ubuntu:trusty
 MAINTAINER Nitrous.IO <hello@nitrous.io>
 
@@ -11,10 +12,9 @@ RUN \
   apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
   echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list && \
   apt-get update && \
-  apt-get install -yq lxc-docker-1.3.0
+  apt-get install -yq lxc-docker-1.4.1
 
-ADD ./dind /dind
-RUN chmod +x /dind
+COPY ./dind /dind
 
 VOLUME /var/lib/docker
 ENTRYPOINT ["/dind"]

--- a/14.04/Makefile
+++ b/14.04/Makefile
@@ -1,4 +1,0 @@
-all:
-	@docker build -t nitrousio/ubuntu-dind:14.04 .
-
-.PHONY: all

--- a/14.10/Dockerfile
+++ b/14.10/Dockerfile
@@ -1,3 +1,4 @@
+# Auto generated Dockerfile, please dont edit
 FROM ubuntu:utopic
 MAINTAINER Nitrous.IO <hello@nitrous.io>
 

--- a/14.10/Makefile
+++ b/14.10/Makefile
@@ -1,4 +1,0 @@
-all:
-	@docker build -t nitrousio/ubuntu-dind:14.10 .
-
-.PHONY: all

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,5 @@
 # Auto generated Dockerfile, please dont edit
-FROM ubuntu:precise
+FROM ubuntu:%VERSION%
 MAINTAINER Nitrous.IO <hello@nitrous.io>
 
 RUN \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,10 @@
-trusty:
-	@cd 14.04 && docker build -t nitrousio/ubuntu-dind:14.04 .
-	@docker tag nitrousio/ubuntu-dind:14.04 nitrousio/ubuntu-dind:trusty
-	@docker tag nitrousio/ubuntu-dind:14.04 nitrousio/ubuntu-dind:trusty-1.3.0
-.PHONY: trusty
+build:
+	@./build.sh
+.PHONY: build
 
-precise:
-	@cd 12.04 && docker build -t nitrousio/ubuntu-dind:12.04 .
-	@docker tag nitrousio/ubuntu-dind:12.04 nitrousio/ubuntu-dind:precise
-	@docker tag nitrousio/ubuntu-dind:12.04 nitrousio/ubuntu-dind:precise-1.3.0
-.PHONY: precise
+push:
+	@./build.sh PUSH
+.PHONY: push
 
-all: trusty precise
+all: build
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 build a container that's capable of running docker daemon (i.e. docker inside
 docker)
+
+#### How to make changes to the images
+
+Change `Dockerfile.template` and `dind`. The changes will be reflected to all
+images when running `make`
+
+#### How to build
+
+Run `make` will build and tag all ubuntu-dind images. Refer to `build.sh` to
+see the build configuration that we used.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+PUSH=$1
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+prepare() {
+  local dir=$1
+  local version=$2
+  mkdir -p $dir
+  sed "s/%VERSION%/$version/g" Dockerfile.template > "$dir/Dockerfile"
+  cp dind "$dir/"
+}
+
+build() {
+  local version=$1
+  local alias=$2
+
+  (
+  cd $version
+  echo "===> docker build -t nitrousio/ubuntu-dind:$version ."
+  docker build -t nitrousio/ubuntu-dind:$version .
+  for a in $alias; do
+    echo "===> docker tag -f nitrousio/ubuntu-dind:$version nitrousio/ubuntu-dind:$a"
+    docker tag -f nitrousio/ubuntu-dind:$version nitrousio/ubuntu-dind:$a
+  done
+  )
+}
+
+prepare "12.04" "precise"
+prepare "14.04" "trusty"
+prepare "14.10" "utopic"
+
+build "12.04" "precise"
+build "14.04" "trusty"
+build "14.10" "utopic latest"
+
+if [[ "$PUSH" == "PUSH" ]]; then
+  echo "===> PUSHING nitrousio/ubuntu-dind ...."
+  docker push nitrousio/ubuntu-dind
+fi

--- a/dind
+++ b/dind
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+# DinD: a wrapper script which allows docker to be run inside a docker container.
+# Original version by Jerome Petazzoni <jerome@dotcloud.com>
+# See the blog post: http://blog.docker.io/2013/09/docker-can-now-run-within-docker/
+#
+# This script should be executed inside a docker container in privilieged mode
+# ('docker run --privileged', introduced in docker 0.6).
+
+# Usage: dind CMD [ARG...]
+
+# apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+export container=docker
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/cgroup
+
+mkdir -p "$CGROUP"
+
+if ! mountpoint -q "$CGROUP"; then
+  mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+    echo >&2 'Could not make a tmpfs mount. Did you use --privileged?'
+    exit 1
+  }
+fi
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+  mount -t securityfs none /sys/kernel/security || {
+    echo >&2 'Could not mount /sys/kernel/security.'
+    echo >&2 'AppArmor detection and -privileged mode might break.'
+  }
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup); do
+  mkdir -p "$CGROUP/$SUBSYS"
+  if ! mountpoint -q $CGROUP/$SUBSYS; then
+    mount -n -t cgroup -o "$SUBSYS" cgroup "$CGROUP/$SUBSYS"
+  fi
+
+  # The two following sections address a bug which manifests itself
+  # by a cryptic "lxc-start: no ns_cgroup option specified" when
+  # trying to start containers withina container.
+  # The bug seems to appear when the cgroup hierarchies are not
+  # mounted on the exact same directories in the host, and in the
+  # container.
+
+  # Named, control-less cgroups are mounted with "-o name=foo"
+  # (and appear as such under /proc/<pid>/cgroup) but are usually
+  # mounted on a directory named "foo" (without the "name=" prefix).
+  # Systemd and OpenRC (and possibly others) both create such a
+  # cgroup. To avoid the aforementioned bug, we symlink "foo" to
+  # "name=foo". This shouldn't have any adverse effect.
+  name="${SUBSYS#name=}"
+  if [ "$name" != "$SUBSYS" ]; then
+    ln -s "$SUBSYS" "$CGROUP/$name"
+  fi
+
+  # Likewise, on at least one system, it has been reported that
+  # systemd would mount the CPU and CPU accounting controllers
+  # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+  # but on a directory called "cpu,cpuacct" (note the inversion
+  # in the order of the groups). This tries to work around it.
+  if [ "$SUBSYS" = 'cpuacct,cpu' ]; then
+    ln -s "$SUBSYS" "$CGROUP/cpu,cpuacct"
+  fi
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+if ! grep -q :devices: /proc/1/cgroup; then
+  echo >&2 'WARNING: the "devices" cgroup should be in its own hierarchy.'
+fi
+if ! grep -qw devices /proc/1/cgroup; then
+  echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
+fi
+
+# Mount /tmp
+mount -t tmpfs none /tmp
+
+if [ $# -gt 0 ]; then
+  exec "$@"
+fi
+
+echo >&2 'ERROR: No command specified.'
+echo >&2 'You probably want to run hack/make.sh, or maybe a shell?'


### PR DESCRIPTION
This also update docker version for all to 1.4.1

Revert to using a generic template i.e. similar to commit 20b5cd01d94c854174cc55eba46905d40e5e0396 but simpler, so we dont have to maintain separate Dockerfiles and dind